### PR TITLE
Show projectName config as header title

### DIFF
--- a/html/js/index.js
+++ b/html/js/index.js
@@ -9,6 +9,10 @@ import { ConfigPage } from './comp/ConfigPage'
 import { FilePage } from './comp/FilePage'
 import { FirmwarePage } from './comp/FirmwarePage'
 
+import Config from './configuration.json';
+
+const header_config = Config && Config.length && Config.filter(opt => opt.name === "projectName").map(opt => opt.value)[0];
+
 if (process.env.NODE_ENV === 'production')
     var url = window.location.origin;
 else
@@ -23,7 +27,9 @@ function Root() {
     <BrowserRouter>
 
         <Header>
-            <h1><Box style={{verticalAlign:"-0.1em"}} /> ESP8266</h1>
+            <h1>
+                <Box style={{ verticalAlign: "-0.1em" }} /> {header_config}
+            </h1>
 
             <Hamburger onClick={() => setMenu(!menu)} />
             <Menu className={menu ? "" : "menuHidden"}>


### PR DESCRIPTION
Split out from https://github.com/maakbaas/esp8266-iot-framework/pull/7 because it needs more consideration

#### todo

- [ ] figure out how to display projectName, but without doing a static import from configuration.json
- [ ] make sure the header text & hamburger menu display appropriately at various browser widths (eg, consider wrapping, etc)